### PR TITLE
Enable non-personalized Ads

### DIFF
--- a/src/Bling.js
+++ b/src/Bling.js
@@ -191,7 +191,17 @@ class Bling extends Component {
          *
          * @property style
          */
-        style: PropTypes.object
+        style: PropTypes.object,
+        /**
+         * An optional property to control non-personalized Ads.
+         * https://support.google.com/admanager/answer/7678538
+         *
+         * Set to `true` to mark the ad request as NPA, and to `false` for ad requests that are eligible for personalized ads
+         * It is `false` by default, according to Google's definition.
+         *
+         * @property npa
+         */
+        npa: PropTypes.bool
     };
 
     /**
@@ -209,7 +219,8 @@ class Bling extends Component {
         "collapseEmptyDiv",
         "companionAdService",
         "forceSafeFrame",
-        "safeFrameConfig"
+        "safeFrameConfig",
+        "npa"
     ];
     /**
      * An array of prop names which requires to create a new ad slot and render as a new ad.
@@ -378,6 +389,11 @@ class Bling extends Component {
             : Bling._config.viewableThreshold;
     }
 
+    componentWillMount() {
+        const {npa} = this.props;
+        this.handleSetNpaFlag(npa);
+    }
+
     componentDidMount() {
         Bling._adManager.addInstance(this);
         Bling._adManager
@@ -387,7 +403,7 @@ class Bling extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        const { propsEqual } = Bling._config;
+        const { propsEqual, npa } = Bling._config;
         const { sizeMapping } = this.props;
         if (
             (nextProps.sizeMapping || sizeMapping) &&
@@ -395,6 +411,8 @@ class Bling extends Component {
         ) {
             Bling._adManager.removeMQListener(this, nextProps);
         }
+
+        this.handleSetNpaFlag(npa);
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -778,6 +796,22 @@ class Bling extends Component {
         this._divId = id || Bling._adManager.generateDivId();
 
         return <div id={this._divId} style={style} />;
+    }
+
+    /**
+     * Call pubads and set the non-personalized Ads flag, if it is not undefined.
+     *
+     * @param {boolean} npa
+     */
+    handleSetNpaFlag(npa) {
+        if (npa !== undefined) {
+            Bling._adManager.pubadsProxy({
+                method: "setRequestNonPersonalizedAds",
+                args: [npa ? 1 : 0],
+                resolve: null,
+                reject: null
+            });
+        }
     }
 }
 

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -408,8 +408,10 @@ class Bling extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        const { propsEqual, npa } = Bling._config;
-        const { sizeMapping } = this.props;
+        const {propsEqual} = Bling._config;
+        const {sizeMapping} = this.props;
+        const {npa} = nextProps;
+
         if (
             (nextProps.sizeMapping || sizeMapping) &&
             !propsEqual(nextProps.sizeMapping, sizeMapping)

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -219,8 +219,7 @@ class Bling extends Component {
         "collapseEmptyDiv",
         "companionAdService",
         "forceSafeFrame",
-        "safeFrameConfig",
-        "npa"
+        "safeFrameConfig"
     ];
     /**
      * An array of prop names which requires to create a new ad slot and render as a new ad.
@@ -228,7 +227,13 @@ class Bling extends Component {
      * @property reRenderProps
      * @static
      */
-    static reRenderProps = ["adUnitPath", "slotSize", "outOfPage", "content"];
+    static reRenderProps = [
+        "adUnitPath",
+        "slotSize",
+        "outOfPage",
+        "content",
+        "npa"
+    ];
     /**
      * An instance of ad manager.
      *
@@ -804,14 +809,16 @@ class Bling extends Component {
      * @param {boolean} npa
      */
     handleSetNpaFlag(npa) {
-        if (npa !== undefined) {
-            Bling._adManager.pubadsProxy({
-                method: "setRequestNonPersonalizedAds",
-                args: [npa ? 1 : 0],
-                resolve: null,
-                reject: null
-            });
+        if (npa === undefined) {
+            return;
         }
+
+        Bling._adManager.pubadsProxy({
+            method: "setRequestNonPersonalizedAds",
+            args: [npa ? 1 : 0],
+            resolve: null,
+            reject: null
+        });
     }
 }
 

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -163,6 +163,40 @@ describe("Bling", () => {
         );
     });
 
+    it("call pubads API to set non-personalized Ads when npa prop is set", () => {
+        const renderer = new ShallowRenderer();
+        const spy = sinon.stub(Bling._adManager, "pubadsProxy");
+        const expectedParam = {
+            method: "setRequestNonPersonalizedAds",
+            args: [1],
+            resolve: null,
+            reject: null
+        };
+
+        renderer.render(
+            <Bling
+                adUnitPath="/4595/nfl.test.open"
+                npa={true}
+                slotSize={["fluid"]}
+            />
+        );
+
+        expect(spy.calledWith(expectedParam)).to.be.true;
+
+        renderer.unmount();
+        renderer.render(
+            <Bling
+                adUnitPath="/4595/nfl.test.open"
+                npa={false}
+                slotSize={["fluid"]}
+            />
+        );
+
+        expectedParam.args = [0];
+        expect(spy.calledWith(expectedParam)).to.be.true;
+        spy.restore();
+    });
+
     it("fires once event", done => {
         const events = Object.keys(Events).map(key => Events[key]);
 


### PR DESCRIPTION
According to EU regulations, it is mandatory to enable users to opt-out to tracking cookies
GPT allows us to respect this law using the `npa` flag on Ads.