### PR TITLE
feature: add limited ads parameter

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/erbium

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -534,7 +534,7 @@ class Bling extends Component {
     }
 
     onScriptError(err) {
-        console.warn(`Ad: Failed to load gpt for ${this.seedUrl()}`, err);
+        console.warn(`Ad: Failed to load gpt for ${this.seedUrl}`, err);
     }
 
     getRenderWhenViewable(props = this.props) {

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -209,9 +209,9 @@ class Bling extends Component {
          * Set to `true` to mark the ad request as limited, and to `false` for the personalized ads requests when user consent has been given.
          * It is `false` by default, according to Google's definition.
          *
-         * @property limited
+         * @property limitedAds
          */
-        limited: PropTypes.bool
+        limitedAds: PropTypes.bool
     };
 
     /**
@@ -229,7 +229,8 @@ class Bling extends Component {
         "collapseEmptyDiv",
         "companionAdService",
         "forceSafeFrame",
-        "safeFrameConfig"
+        "safeFrameConfig",
+        "limitedAds"
     ];
     /**
      * An array of prop names which requires to create a new ad slot and render as a new ad.
@@ -242,7 +243,8 @@ class Bling extends Component {
         "slotSize",
         "outOfPage",
         "content",
-        "npa"
+        "npa",
+        "limitedAds"
     ];
     /**
      * An instance of ad manager.
@@ -412,10 +414,10 @@ class Bling extends Component {
             : Bling._config.viewableThreshold;
     }
 
-    getSeedUrl() {
-        const {limited} = this.props;
+    get seedUrl() {
+        const {limitedAds} = this.props;
 
-        if (limited) {
+        if (limitedAds) {
             return Bling._config.seedFileUrlLimited;
         }
 
@@ -425,7 +427,7 @@ class Bling extends Component {
     componentDidMount() {
         Bling._adManager.addInstance(this);
         Bling._adManager
-            .load(this.getSeedUrl())
+            .load(this.seedUrl)
             .then(this.onScriptLoaded.bind(this))
             .catch(this.onScriptError.bind(this));
     }
@@ -532,7 +534,7 @@ class Bling extends Component {
     }
 
     onScriptError(err) {
-        console.warn(`Ad: Failed to load gpt for ${this.getSeedUrl()}`, err);
+        console.warn(`Ad: Failed to load gpt for ${this.seedUrl()}`, err);
     }
 
     getRenderWhenViewable(props = this.props) {
@@ -599,6 +601,10 @@ class Bling extends Component {
                 adSlot.setTargeting(key, targeting[key]);
             });
         }
+    }
+
+    setLimited(limited) {
+        Bling._adManager.setLimited(limited);
     }
 
     addCompanionAdService(serviceConfig, adSlot) {
@@ -678,7 +684,8 @@ class Bling extends Component {
             safeFrameConfig,
             content,
             clickUrl,
-            forceSafeFrame
+            forceSafeFrame,
+            limitedAds
         } = props;
 
         this.defineSizeMapping(adSlot, sizeMapping);
@@ -713,6 +720,9 @@ class Bling extends Component {
 
         // Sets custom targeting parameters
         this.setTargeting(adSlot, targeting);
+
+        // Sets serving limited ads
+        this.setLimited(limitedAds);
 
         if (safeFrameConfig) {
             adSlot.setSafeFrameConfig(safeFrameConfig);

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -201,7 +201,17 @@ class Bling extends Component {
          *
          * @property npa
          */
-        npa: PropTypes.bool
+        npa: PropTypes.bool,
+        /**
+         * An optional property to configure if GPT should be loaded from the limited ads source rather than from the official source.
+         * https://developers.google.com/publisher-tag/guides/general-best-practices?hl=en#load_from_an_official_source
+         *
+         * Set to `true` to mark the ad request as limited, and to `false` for the personalized ads requests when user consent has been given.
+         * It is `false` by default, according to Google's definition.
+         *
+         * @property limited
+         */
+        limited: PropTypes.bool
     };
 
     /**
@@ -251,8 +261,16 @@ class Bling extends Component {
     static _config = {
         /**
          * An optional string for GPT seed file url to override.
+         * Defaults to the officially recommended GPT url.
+         * https://developers.google.com/publisher-tag/guides/general-best-practices?hl=en#load_from_an_official_source
          */
-        seedFileUrl: "//www.googletagservices.com/tag/js/gpt.js",
+        seedFileUrl: "//securepubads.g.doubleclick.net/tag/js/gpt.js",
+        /**
+         * An optional string for the limited GPT seed file url to override.
+         * Defaults to the officially recommended limited GPT url.
+         * https://developers.google.com/publisher-tag/guides/general-best-practices?hl=en#load_from_an_official_source
+         */
+        seedFileUrlLimited: "//pagead2.googlesyndication.com/tag/js/gpt.js",
         /**
          * An optional flag to indicate whether an ad should only render when it's fully in the viewport area. Default is `true`.
          */
@@ -394,10 +412,20 @@ class Bling extends Component {
             : Bling._config.viewableThreshold;
     }
 
+    getSeedUrl() {
+        const {limited} = this.props;
+
+        if (limited) {
+            return Bling._config.seedFileUrlLimited;
+        }
+
+        return Bling._config.seedFileUrl;
+    }
+
     componentDidMount() {
         Bling._adManager.addInstance(this);
         Bling._adManager
-            .load(Bling._config.seedFileUrl)
+            .load(this.getSeedUrl())
             .then(this.onScriptLoaded.bind(this))
             .catch(this.onScriptError.bind(this));
     }
@@ -504,10 +532,7 @@ class Bling extends Component {
     }
 
     onScriptError(err) {
-        console.warn(
-            `Ad: Failed to load gpt for ${Bling._config.seedFileUrl}`,
-            err
-        );
+        console.warn(`Ad: Failed to load gpt for ${this.getSeedUrl()}`, err);
     }
 
     getRenderWhenViewable(props = this.props) {

--- a/src/createManager.js
+++ b/src/createManager.js
@@ -97,6 +97,15 @@ export class AdManager extends EventEmitter {
         }
     }
 
+    _setPrivacySettings(custom = {}) {
+        const config = this.googletag.PrivacySettingsConfig;
+
+        // based on https://developers.google.com/publisher-tag/reference#googletag.privacysettingsconfig
+        this.googletag.PrivacySettingsConfig = config
+            ? {...config, ...custom}
+            : custom;
+    }
+
     _processPubadsQueue() {
         if (this._pubadsProxyQueue) {
             Object.keys(this._pubadsProxyQueue).forEach(method => {
@@ -305,6 +314,18 @@ export class AdManager extends EventEmitter {
                 );
                 delete this._mqls[key];
             }
+        });
+    }
+
+    /**
+     * Sets the tag manager to use limited ads when customer compliance is not given.
+     *
+     * @param {Boolean} limited A boolean signaling if limited ads should be shown [true] or not [false/omitted].
+     */
+    setLimited(limited) {
+        this._setPrivacySettings({
+            // based on https://developers.google.com/publisher-tag/reference#boolean-limitedads
+            limitedAds: !!limited
         });
     }
 

--- a/src/createManager.js
+++ b/src/createManager.js
@@ -97,15 +97,6 @@ export class AdManager extends EventEmitter {
         }
     }
 
-    _setPrivacySettings(custom = {}) {
-        const config = this.googletag.PrivacySettingsConfig;
-
-        // based on https://developers.google.com/publisher-tag/reference#googletag.privacysettingsconfig
-        this.googletag.PrivacySettingsConfig = config
-            ? {...config, ...custom}
-            : custom;
-    }
-
     _processPubadsQueue() {
         if (this._pubadsProxyQueue) {
             Object.keys(this._pubadsProxyQueue).forEach(method => {
@@ -323,9 +314,13 @@ export class AdManager extends EventEmitter {
      * @param {Boolean} limited A boolean signaling if limited ads should be shown [true] or not [false/omitted].
      */
     setLimited(limited) {
-        this._setPrivacySettings({
-            // based on https://developers.google.com/publisher-tag/reference#boolean-limitedads
-            limitedAds: !!limited
+        this.googletag.cmd.push(() => {
+            this.googletag.pubads().setPrivacySettings({
+                limitedAds: limited
+            });
+
+            // Refresh all ads on the page.
+            this.googletag.pubads().refresh();
         });
     }
 


### PR DESCRIPTION
With GDPR a user can choose to not give permission to have his private data sent to tracking providers. For this purpose Google has implemented the limited ads privacy setting. Choosing this setting comes with a changed URL for the GPT source, an additional "ltd" parameter for all xhr calls to the actual ads and will prevent sending cookies to the ads server.