### PR TITLE
fix(AD-0): Fix race conditions within shouldComponentUpdate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@carlos.algms/react-gpt",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "A react display ad component using Google Publisher Tag",
     "main": "lib/index.js",
     "jsnext:main": "es/index.js",


### PR DESCRIPTION
Removed `limitedAds` from refreshable props as this must trigger re-render and these sets must be distinct. `shouldComponentUpdate` must never throw. No updates should be made until the backing API is ready (`Bling._adManager.pubadsReady`). Carried 1 diverged change from upstream - https://github.com/nfl/react-gpt/commit/d8143952da5dc64b00dfe284b5e01ed7c26d8bf1
Seed files must be fetched over HTTPS (they redirect anyway) - HTTP is not secure (this is 2021 guys 😉)