### PR TITLE
Allow early size mapping setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@carlos.algms/react-gpt",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "A react display ad component using Google Publisher Tag",
     "main": "lib/index.js",
     "jsnext:main": "es/index.js",

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -574,7 +574,7 @@ class Bling extends Component {
     }
 
     defineSizeMapping(adSlot, sizeMapping) {
-        if (Bling._adManager.pubadsReady && sizeMapping) {
+        if (sizeMapping) {
             Bling._adManager.addMQListener(this, this.props);
             const sizeMappingArray = sizeMapping
                 .reduce((mapping, size) => {


### PR DESCRIPTION
Size mapping is tried to be set before pubsads are ready.  This is a revert of https://github.com/carlos-algms/react-gpt/pull/4/files#diff-f8ded06eb388cfe8c79bfb30d27ccb76fb58636b119dd80caa9a9b7a2f28ef71R577 - it is safe to call size mapping setters even with no pubsads instance being ready.

<img width="322" alt="Zrzut ekranu 2021-12-1 o 09 23 33" src="https://user-images.githubusercontent.com/30114244/144198146-8b7a28f2-fe56-4e7a-9a96-286de4edbc7b.png">
