### PR TITLE
feat: use crossorigin attribute

### DIFF
--- a/src/createManager.js
+++ b/src/createManager.js
@@ -511,6 +511,7 @@ export class AdManager extends EventEmitter {
                     const script = document.createElement("script");
                     script.async = true;
                     script.onload = onLoad;
+                    script.setAttribute("crossorigin", "anonymous");
                     script.onerror = () => {
                         reject(new Error("failed to load script"));
                     };


### PR DESCRIPTION
This PR should tackle the following CORB issue that comes from a series of network requests, shown by the following screenshot.

![Screenshot 2024-10-07 at 14 10 32](https://github.com/user-attachments/assets/ce64d792-2961-45c1-95d1-4643305c1cae)

![Screenshot 2024-10-07 at 14 40 52](https://github.com/user-attachments/assets/a9517b7e-6fd0-498a-9eae-693ba257f6c0)

The URL `pagead2.googlesyndication.com/pagead/sodar` (the last item in the initiator chain) is being requested by several succeeding scripts, starting from `pagead2.googlesyndication.com/tag/js/gpt.js` which itself is being requested via a `<script>` tag. Since the tag does not have a `crossorigin="anonymous` attribute, the CORB safeguard kicks in and the browser blocks the request.

Further information: https://www.chromium.org/Home/chromium-security/corb-for-developers/